### PR TITLE
Fix init module name when sub-directory

### DIFF
--- a/hotload.py
+++ b/hotload.py
@@ -217,7 +217,7 @@ Example usage:
         print(USAGE)
         sys.exit(1)
 
-    init_module = re.sub(r"\.py", "", sys.argv[1])
+    init_module = re.sub(r"\.py", "", sys.argv[1]).replace("/", ".")
 
     os.environ["HOTLOAD_RUNNING"] = "HOTLOAD_RUNNING"
 


### PR DESCRIPTION
Example usage:

    find . -name '*.py' | hotload init.py

did not work for e.g.:

    find . -name '*.py' | hotload test/test.py
