### PR TITLE
Test2

### DIFF
--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+cat <<EOF >lib.py
+x = 3
+y = 4
+print("Result: {}".format(x*x + y*y))
+EOF
+touch -t 200711121015 lib.py
+
+echo lib.py | python3 -u ./hotload.py lib.py > output &
+pid="$!"
+
+sleep 0.1
+sed -i.bak "s/x = ./x = 4/" lib.py
+sleep 0.1
+kill "$pid"
+
+strings output | grep -o -m1 'Successfully reloaded lib'
+strings output | grep -o -m1 'Result: 25$'
+strings output | grep -o -m1 'Result: 32$'
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,15 @@
+name: test
+
+on:
+  push
+
+jobs:
+  shelltest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - run: sh .github/workflows/test.sh
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,5 +11,5 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.x'
-      - run: sh .github/workflows/test.sh
+      - run: sh -x .github/workflows/test.sh
 


### PR DESCRIPTION
Rewrite shell test to avoid `sleep` and polling. Ref https://github.com/teodorlu/hotload/pull/5

The output from hotload.py is piped to a subshell command group 
containing a sequence of `expect` function calls.
These functions assert that the expected strings are observered, in order. (Ignoring other output interspersed.)

After running the test, we want to tidy up and end the python process. To get its PID we need to use a named pipe, `"$pipe"`.

To avoid infinite "hang", a timeout is set by running `sleep` in parallell with the tests. Again a named pipe is needed, in this case to wait for the first of the jobs (tests, sleep) to finish. The main process reads from FIFO pipe `$done_chan`, blocking until a message is received.

The test runs pretty fast: https://github.com/teodorlu/hotload/runs/7297455043

```
2022-07-12T07:58:27.8053635Z ##[group]Run sh -x .github/workflows/test.sh
...
2022-07-12T07:58:28.2685395Z Tests OK!
```
=> 0.463 seconds. About 0.09s on my laptop. Remember, this includes starting python and several other processes (sed etc.).