### PR TITLE
Test3 - apocalypse

### DIFF
--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -75,13 +75,13 @@ end() {
     esac
     trap - EXIT
     if [ -e "$done_chan" ]; then rm "$done_chan"; fi
-    silent kill $(decendants)
+    silent kill $(descendants)
 }
 
-decendants() {
-    ps -o pid -o ppid | piddecendants $PID
+descendants() {
+    ps -o pid -o ppid | piddescendants $PID
 }
-piddecendants() {
+piddescendants() {
     # Prints given PID preceded by all its (great...)-grandchildren and children
     awk -v root=$1 'NR > 1 {
         parent[$1] = $2

--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -3,6 +3,7 @@ set -e
 trap 'end EXIT' EXIT
 trap 'end TERM' TERM
 trap 'end INT' INT
+PID=$$
 
 main(){
     done_chan="${TMPDIR}chan$$"
@@ -78,7 +79,7 @@ end() {
 }
 
 decendants() {
-    ps -o pid -o ppid | piddecendants $$
+    ps -o pid -o ppid | piddecendants $PID
 }
 piddecendants() {
     # Prints given PID preceded by all its (great...)-grandchildren and children

--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -e
 trap 'end EXIT' EXIT
 trap 'end TERM' TERM
@@ -22,6 +22,7 @@ main(){
 }
 
 tests(){ done_chan="$1"
+    trap '[ -z "$pid" ] || kill $pid; [ -e "$pipe" ] && rm "$pipe" || true' EXIT
 
     cat <<-EOF >lib.py
 	x = 3
@@ -72,6 +73,7 @@ end() {
             trap 'trap - TERM; kill -s INT $$' TERM ;;
     esac
     trap - EXIT
+    if [ -e "$done_chan" ]; then rm "$done_chan"; fi
     silent kill $(decendants)
 }
 


### PR DESCRIPTION
"Test2", https://github.com/teodorlu/hotload/pull/11, works pretty well, but does not clean up all processes on errors.

### Traps galore — Signal madness 3e6bfb7

Make sure all child processes are killed when script ends, both when successful and otherwise.

Put cleanup code in a single top-level function, `end()`. So far so good.

Send kill signal to all children by getting pgid (process group id) of all jobs.

The script should quit with the correct exit code, so we have to set `trap 'exit $?' TERM`.

We cannot send SIGINT to the asynchronous commands (it's ignored when job control is disabled),
so TERM is sent, and `trap 'trap - TERM; kill -s INT $$' TERM` is set for the parent process.

### PID armageddon! 5e2a66e

Kill each PID decentant.

GitHub runs the script in the same process group as the runner, so killing the process group is problematic.

This commit kills every decendant PID instead.

Not sure if the order matters, so to be on the safe side the youngest PIDs are printed first.

I.e. we call `kill GRANDCHILD1 GRANDCHILD2 CHILD1 CHILD2 PARENT`

The function prints lines of:

    ...
    GREAT ** N  GRANDCHILDREN  (N >= 2)
    GREAT GRANDCHILDREN
    GRANDCHILDREN
    CHILDREN
    PARENT (`root`)

#### kill $pid and cleanup fifos 820c45c

On successful runs, $pid did not terminate, getting parent PID 1.

Add EXIT trap to terminate $pid, and also delete FIFOs.

The EXIT trap is called on all exits in Bash, including SIGTERM.

Other shells runs EXIT trap only in the absence of signals.

Keeping this generic is too much work, the shebang reflects Bash requirement.